### PR TITLE
Ip address drilldown

### DIFF
--- a/nerdlets/network-telemetry-overview/ip-address.jsx
+++ b/nerdlets/network-telemetry-overview/ip-address.jsx
@@ -1,50 +1,56 @@
-import React from 'react'
-import {Toast, navigation} from 'nr1'
+import { Toast, navigation } from "nr1";
+import PropTypes from "prop-types";
+import React from "react";
 
-import findRelatedAccountsWith from '../../src/lib/find-related-account-with'
-import nrdbQuery from '../../src/lib/nrdb-query'
+import findRelatedAccountsWith from "../../src/lib/find-related-account-with";
+import nrdbQuery from "../../src/lib/nrdb-query";
 
 /**
  * render an ip address that on click will attempt to find the
- * host associated with it. Look at NetworkSample event data 
+ * host associated with it. Look at NetworkSample event data
  * and search across all accounts.
  */
 export default class IpAddress extends React.Component {
-  constructor(props) {
-    super(props)
+  static propTypes = {
+    value: PropTypes.string,
+  };
 
-    this.onClick = this.onClick.bind(this)
+  constructor(props) {
+    super(props);
+
+    this.onClick = this.onClick.bind(this);
   }
 
   async onClick() {
-    const ipAddress = this.props.value
-    if(!ipAddress) return
-  
-    this.setState({searching: true})
-    const where = `ipV4Address like '${ipAddress}/%'`
-    const accounts = await findRelatedAccountsWith({eventType: "NetworkSample", where})
-    if(accounts.length == 0) {
+    const ipAddress = this.props.value;
+    if (!ipAddress) return;
+
+    this.setState({ searching: true });
+    const where = `ipV4Address like '${ipAddress}/%'`;
+    const accounts = await findRelatedAccountsWith({ eventType: "NetworkSample", where });
+    if (accounts.length === 0) {
       Toast.showToast({
-        title: "IP Address Not Found",
         description: `Could not find ${ipAddress} on any monitored hosts.`,
-        type: Toast.TYPE.NORMAL
-      })
+        title: "IP Address Not Found",
+        type: Toast.TYPE.NORMAL,
+      });
+    } else {
+      const account = accounts[0];
+      const nrql = `SELECT latest(entityGuid) as entityGuid FROM NetworkSample WHERE ${where} SINCE 2 minutes ago`;
+      const results = await nrdbQuery(account.id, nrql);
+      const { entityGuid } = results[0];
+      navigation.openStackedEntity(entityGuid);
     }
-    else {
-      const account = accounts[0]
-      const nrql = `SELECT latest(entityGuid) as entityGuid FROM NetworkSample WHERE ${where} SINCE 2 minutes ago`
-      const results = await nrdbQuery(account.id, nrql) 
-      const {entityGuid} = results[0]
-      navigation.openStackedEntity(entityGuid)
-    }
-    this.setState({searching: false})
+    this.setState({ searching: false });
   }
 
   render() {
-    const {searching} = this.state || {}
-    const className = searching ? "ip-address-searching" : "ip-address"
-    return <div className={className} onClick={this.onClick}>
-      {this.props.value || "(unknown)"}
-    </div>
+    const { searching } = this.state || {};
+    const className = searching ? "ip-address-searching" : "ip-address";
+    return (
+      <div className={className} onClick={this.onClick}>
+        {this.props.value || "(unknown)"}
+      </div>
+    );
   }
 }

--- a/nerdlets/network-telemetry-overview/ip-address.jsx
+++ b/nerdlets/network-telemetry-overview/ip-address.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import {Toast, navigation} from 'nr1'
+
+import findRelatedAccountsWith from '../../src/lib/find-related-account-with'
+import nrdbQuery from '../../src/lib/nrdb-query'
+
+/**
+ * render an ip address that on click will attempt to find the
+ * host associated with it. Look at NetworkSample event data 
+ * and search across all accounts.
+ */
+export default class IpAddress extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.onClick = this.onClick.bind(this)
+  }
+
+  async onClick() {
+    const ipAddress = this.props.value
+    if(!ipAddress) return
+  
+    this.setState({searching: true})
+    const where = `ipV4Address like '${ipAddress}/%'`
+    const accounts = await findRelatedAccountsWith({eventType: "NetworkSample", where})
+    if(accounts.length == 0) {
+      Toast.showToast({
+        title: "IP Address Not Found",
+        description: `Could not find ${ipAddress} on any monitored hosts.`,
+        type: Toast.TYPE.NORMAL
+      })
+    }
+    else {
+      const account = accounts[0]
+      const nrql = `SELECT latest(entityGuid) as entityGuid FROM NetworkSample WHERE ${where} SINCE 2 minutes ago`
+      const results = await nrdbQuery(account.id, nrql) 
+      const {entityGuid} = results[0]
+      navigation.openStackedEntity(entityGuid)
+    }
+    this.setState({searching: false})
+  }
+
+  render() {
+    const {searching} = this.state || {}
+    const className = searching ? "ip-address-searching" : "ip-address"
+    return <div className={className} onClick={this.onClick}>
+      {this.props.value || "(unknown)"}
+    </div>
+  }
+}

--- a/nerdlets/network-telemetry-overview/ip-address.jsx
+++ b/nerdlets/network-telemetry-overview/ip-address.jsx
@@ -48,7 +48,13 @@ export default class IpAddress extends React.Component {
     const { searching } = this.state || {};
     const className = searching ? "ip-address-searching" : "ip-address";
     return (
-      <div className={className} onClick={this.onClick}>
+      <div
+        className={className}
+        onClick={this.onClick}
+        onKeyPress={this.onClick}
+        role='button'
+        tabIndex={0}
+      >
         {this.props.value || "(unknown)"}
       </div>
     );

--- a/nerdlets/network-telemetry-overview/network-summary.jsx
+++ b/nerdlets/network-telemetry-overview/network-summary.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { Table } from "semantic-ui-react";
 import { renderDeviceHeader } from "./common";
-import IpAddress from './ip-address'
+import IpAddress from "./ip-address";
 
 export default class NetworkSummary extends React.Component {
   static propTypes = {
@@ -61,7 +61,7 @@ export default class NetworkSummary extends React.Component {
                 default:
                   return (
                     <Table.Cell key={`${idx}-${i}`}>
-                      <IpAddress value={node[c.data]}/>
+                      <IpAddress value={node[c.data]} />
                     </Table.Cell>
                   );
               }

--- a/nerdlets/network-telemetry-overview/network-summary.jsx
+++ b/nerdlets/network-telemetry-overview/network-summary.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { Table } from "semantic-ui-react";
 import { renderDeviceHeader } from "./common";
+import IpAddress from './ip-address'
 
 export default class NetworkSummary extends React.Component {
   static propTypes = {
@@ -60,7 +61,7 @@ export default class NetworkSummary extends React.Component {
                 default:
                   return (
                     <Table.Cell key={`${idx}-${i}`}>
-                      {node[c.data] !== null ? node[c.data] : "(unknown)"}
+                      <IpAddress value={node[c.data]}/>
                     </Table.Cell>
                   );
               }

--- a/nerdlets/network-telemetry-overview/network-summary.jsx
+++ b/nerdlets/network-telemetry-overview/network-summary.jsx
@@ -1,10 +1,10 @@
 import { bitsToSize, intToSize } from "../../src/lib/bytes-to-size";
 
+import IpAddress from "./ip-address";
 import PropTypes from "prop-types";
 import React from "react";
 import { Table } from "semantic-ui-react";
 import { renderDeviceHeader } from "./common";
-import IpAddress from "./ip-address";
 
 export default class NetworkSummary extends React.Component {
   static propTypes = {

--- a/nerdlets/network-telemetry-overview/styles.scss
+++ b/nerdlets/network-telemetry-overview/styles.scss
@@ -173,3 +173,11 @@ label {
 .select-account {
   margin: 20px;
 }
+
+.ip-address:hover {
+  cursor: pointer;
+}
+
+.ip-address-searching:hover {
+  cursor: wait;  
+}

--- a/nerdlets/network-telemetry-overview/styles.scss
+++ b/nerdlets/network-telemetry-overview/styles.scss
@@ -179,5 +179,5 @@ label {
 }
 
 .ip-address-searching:hover {
-  cursor: wait;  
+  cursor: wait;
 }

--- a/src/lib/accounts-with-data.js
+++ b/src/lib/accounts-with-data.js
@@ -1,0 +1,19 @@
+import {NerdGraphQuery} from 'nr1'
+
+
+/**
+ * For building account pickers, etc. Get the list of all visible accounts that have
+ * data for the given event type. For examlpe, if you send `SystemSample` you'll get
+ * a list of all accounts with Infratructure installed.  Clean up those account menus!
+ */
+export default async function accountsWithData(eventType) {
+  const gql = `{actor {accounts {name id reportingEventTypes(filter:["${eventType}"])}}}`
+  let result = await NerdGraphQuery.query({query: gql}) 
+  if(result.errors) {
+    console.log("Can't get reporting event types because NRDB is grumpy at NerdGraph.", result.errors)
+    console.log(JSON.stringify(result.errors.slice(0, 5), 0, 2))
+    return []
+  }
+
+  return result.data.actor.accounts.filter(a => a.reportingEventTypes.length > 0)
+}

--- a/src/lib/accounts-with-data.js
+++ b/src/lib/accounts-with-data.js
@@ -1,5 +1,4 @@
-import {NerdGraphQuery} from 'nr1'
-
+import { NerdGraphQuery } from "nr1";
 
 /**
  * For building account pickers, etc. Get the list of all visible accounts that have
@@ -7,13 +6,16 @@ import {NerdGraphQuery} from 'nr1'
  * a list of all accounts with Infratructure installed.  Clean up those account menus!
  */
 export default async function accountsWithData(eventType) {
-  const gql = `{actor {accounts {name id reportingEventTypes(filter:["${eventType}"])}}}`
-  let result = await NerdGraphQuery.query({query: gql}) 
-  if(result.errors) {
-    console.log("Can't get reporting event types because NRDB is grumpy at NerdGraph.", result.errors)
-    console.log(JSON.stringify(result.errors.slice(0, 5), 0, 2))
-    return []
+  const gql = `{actor {accounts {name id reportingEventTypes(filter:["${eventType}"])}}}`;
+  const result = await NerdGraphQuery.query({ query: gql });
+  if (result.errors) {
+    console.warn(
+      "Can't get reporting event types because NRDB is grumpy at NerdGraph.",
+      result.errors
+    );
+    console.warn(JSON.stringify(result.errors.slice(0, 5), 0, 2));
+    return [];
   }
 
-  return result.data.actor.accounts.filter(a => a.reportingEventTypes.length > 0)
+  return result.data.actor.accounts.filter(a => a.reportingEventTypes.length > 0);
 }

--- a/src/lib/find-related-account-with.js
+++ b/src/lib/find-related-account-with.js
@@ -1,36 +1,36 @@
-
-
-import nrdbQuery from './nrdb-query'
-import accountsWithData from './accounts-with-data'
+import nrdbQuery from "./nrdb-query";
+import accountsWithData from "./accounts-with-data";
 
 /**
  * look across all the accounts the user has access to, scoped to the provided
  * event type, and find any accounts that have a match on the provided where clause.
- * Useful for connecting entities/guids etc across account boundaries. 
- * 
+ * Useful for connecting entities/guids etc across account boundaries.
+ *
  * As an optimization, we only query accounts that have event data of the provided type.
  * Beware that for customers with lots of accounts and a common event type (e.g. Transaction)
  * this could take a while. By default we use a short time window to keep queries light.
- * 
+ *
  * Run account queries in parallel (limited by the browser's capacity for parallel requests)
  * and return the array of accounts, each with a hit count in descending order.
  */
-export default async function findRelatedAccountsWith({eventType, where, timeWindow}) {
-  timeWindow = timeWindow || "SINCE 2 minutes ago"
+export default async function findRelatedAccountsWith({ eventType, where, timeWindow }) {
+  timeWindow = timeWindow || "SINCE 2 minutes ago";
 
-  const accounts = await accountsWithData(eventType)
-  const nrql = `SELECT count(*) FROM ${eventType} WHERE ${where} ${timeWindow}`
+  const accounts = await accountsWithData(eventType);
+  const nrql = `SELECT count(*) FROM ${eventType} WHERE ${where} ${timeWindow}`;
 
-  const result = []
-  await Promise.all(accounts.map(async account => {
-    return await nrdbQuery(account.id, nrql).then(results => {
-      const hitCount = results[0].count
-      if(hitCount > 0) {
-        account.hitCount = hitCount
-        result.push(account)
-      }
+  const result = [];
+  await Promise.all(
+    accounts.map(async account => {
+      return await nrdbQuery(account.id, nrql).then(results => {
+        const hitCount = results[0].count;
+        if (hitCount > 0) {
+          account.hitCount = hitCount;
+          result.push(account);
+        }
+      });
     })
-  }))
+  );
 
-  return result.sort((a, b) => b.hitCount - a.hitCount)
+  return result.sort((a, b) => b.hitCount - a.hitCount);
 }

--- a/src/lib/find-related-account-with.js
+++ b/src/lib/find-related-account-with.js
@@ -1,0 +1,36 @@
+
+
+import nrdbQuery from './nrdb-query'
+import accountsWithData from './accounts-with-data'
+
+/**
+ * look across all the accounts the user has access to, scoped to the provided
+ * event type, and find any accounts that have a match on the provided where clause.
+ * Useful for connecting entities/guids etc across account boundaries. 
+ * 
+ * As an optimization, we only query accounts that have event data of the provided type.
+ * Beware that for customers with lots of accounts and a common event type (e.g. Transaction)
+ * this could take a while. By default we use a short time window to keep queries light.
+ * 
+ * Run account queries in parallel (limited by the browser's capacity for parallel requests)
+ * and return the array of accounts, each with a hit count in descending order.
+ */
+export default async function findRelatedAccountsWith({eventType, where, timeWindow}) {
+  timeWindow = timeWindow || "SINCE 2 minutes ago"
+
+  const accounts = await accountsWithData(eventType)
+  const nrql = `SELECT count(*) FROM ${eventType} WHERE ${where} ${timeWindow}`
+
+  const result = []
+  await Promise.all(accounts.map(async account => {
+    return await nrdbQuery(account.id, nrql).then(results => {
+      const hitCount = results[0].count
+      if(hitCount > 0) {
+        account.hitCount = hitCount
+        result.push(account)
+      }
+    })
+  }))
+
+  return result.sort((a, b) => b.hitCount - a.hitCount)
+}

--- a/src/lib/find-related-account-with.js
+++ b/src/lib/find-related-account-with.js
@@ -1,5 +1,5 @@
-import nrdbQuery from "./nrdb-query";
 import accountsWithData from "./accounts-with-data";
+import nrdbQuery from "./nrdb-query";
 
 /**
  * look across all the accounts the user has access to, scoped to the provided
@@ -22,7 +22,7 @@ export default async function findRelatedAccountsWith({ eventType, where, timeWi
   const result = [];
   await Promise.all(
     accounts.map(async account => {
-      return await nrdbQuery(account.id, nrql).then(results => {
+      return nrdbQuery(account.id, nrql).then(results => {
         const hitCount = results[0].count;
         if (hitCount > 0) {
           account.hitCount = hitCount;

--- a/src/lib/nrdb-query.js
+++ b/src/lib/nrdb-query.js
@@ -1,12 +1,12 @@
-import {NerdGraphQuery} from 'nr1'
+import { NerdGraphQuery } from "nr1";
 
 export default async function nrdbQuery(accountId, nrql) {
-  if(!nrql) {
-    console.log("You probably forgot to provide an accountId", accountId)
-    throw nrql
-  } 
+  if (!nrql) {
+    console.warn("You probably forgot to provide an accountId", accountId);
+    throw nrql;
+  }
 
-  nrql = nrql.replace(/\n/g, " ")
+  nrql = nrql.replace(/\n/g, " ");
   const gql = `{
     actor {
       account(id: ${accountId}) {
@@ -15,18 +15,17 @@ export default async function nrdbQuery(accountId, nrql) {
         }
       }
     }
-  }`
+  }`;
 
   try {
-    const {data, error} = await NerdGraphQuery.query({query: gql})
-    if(error || !data.actor.account.nrql) {
-      throw "Bad NRQL Query: " + nrql + ": " + error
+    const { data, error } = await NerdGraphQuery.query({ query: gql });
+    if (error || !data.actor.account.nrql) {
+      throw "Bad NRQL Query: " + nrql + ": " + error;
     }
 
-    return data.actor.account.nrql.results
-  }
-  catch(e) {
-    console.log("NRDB Query Error", nrql,e)
-    throw e
+    return data.actor.account.nrql.results;
+  } catch (e) {
+    console.warn("NRDB Query Error", nrql, e);
+    throw e;
   }
 }

--- a/src/lib/nrdb-query.js
+++ b/src/lib/nrdb-query.js
@@ -1,0 +1,32 @@
+import {NerdGraphQuery} from 'nr1'
+
+export default async function nrdbQuery(accountId, nrql) {
+  if(!nrql) {
+    console.log("You probably forgot to provide an accountId", accountId)
+    throw nrql
+  } 
+
+  nrql = nrql.replace(/\n/g, " ")
+  const gql = `{
+    actor {
+      account(id: ${accountId}) {
+        nrql(query: "${nrql}") {
+          results
+        }
+      }
+    }
+  }`
+
+  try {
+    const {data, error} = await NerdGraphQuery.query({query: gql})
+    if(error || !data.actor.account.nrql) {
+      throw "Bad NRQL Query: " + nrql + ": " + error
+    }
+
+    return data.actor.account.nrql.results
+  }
+  catch(e) {
+    console.log("NRDB Query Error", nrql,e)
+    throw e
+  }
+}

--- a/src/lib/nrdb-query.js
+++ b/src/lib/nrdb-query.js
@@ -20,7 +20,7 @@ export default async function nrdbQuery(accountId, nrql) {
   try {
     const { data, error } = await NerdGraphQuery.query({ query: gql });
     if (error || !data.actor.account.nrql) {
-      throw "Bad NRQL Query: " + nrql + ": " + error;
+      throw new Error("Bad NRQL Query: " + nrql + ": " + error);
     }
 
     return data.actor.account.nrql.results;


### PR DESCRIPTION
When clicking on ip address, search across all accounts with `NetworkSample` telemetry, find a related host entity, and then show that host in an overlay.

The above process can take a few seconds searching across many accounts, so we do the work lazily on click, since there may be hundreds of IP addresses displayed at any given time.