### PR TITLE
feat: limit width of src in network summary table

### DIFF
--- a/nerdlets/network-telemetry-overview/styles.scss
+++ b/nerdlets/network-telemetry-overview/styles.scss
@@ -174,6 +174,13 @@ label {
   margin: 20px;
 }
 
+.ip-address {
+  max-width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .ip-address:hover {
   cursor: pointer;
 }


### PR DESCRIPTION
I'm confident that this little change will prevent the source column in the network telemetry table from expanding to a width that causes scroll overflow or worse:

<img width="992" alt="Captura de Pantalla 2020-01-28 a la(s) 1 24 15 p  m" src="https://user-images.githubusercontent.com/812989/73293229-7d0a0380-41d1-11ea-97dd-e62876085f29.png">


Unfortunately I haven't actually been able to test it because not accounts are showing up for me in the account picker and I'm not sure why. @jthurman42 Do you know off of the top of your head why this might be? I'd like to test this out before it gets merged in.