### PR TITLE
Remove deprecated sizeType prop from nr1 Icon

### DIFF
--- a/nerdlets/network-telemetry-overview/MainMenu.jsx
+++ b/nerdlets/network-telemetry-overview/MainMenu.jsx
@@ -27,9 +27,9 @@ export default class MainMenu extends React.Component {
     const intervalSeconds = props.nerdletUrlState.intervalSeconds || INTERVAL_SECONDS_DEFAULT;
 
     this.state = {
+      intervalEnabled: true,
       intervalSlider: intervalSeconds,
       isLoading: true,
-      intervalEnabled: true,
     };
   }
 

--- a/nerdlets/network-telemetry-overview/network-telemetry-nerdlet.jsx
+++ b/nerdlets/network-telemetry-overview/network-telemetry-nerdlet.jsx
@@ -39,8 +39,11 @@ export default class NetworkTelemetryNerdlet extends React.Component {
   renderSelectAccountAlert = () => {
     return (
       <div className='select-account'>
-        <HeadingText type={HeadingText.TYPE.HEADING_1}>
-          <Icon type={Icon.TYPE.INTERFACE__ARROW__ARROW_LEFT} />
+        <HeadingText type={HeadingText.TYPE.HEADING_2}>
+          <Icon
+            spacingType={[Icon.SPACING_TYPE.NONE, Icon.SPACING_TYPE.LARGE]}
+            type={Icon.TYPE.INTERFACE__ARROW__ARROW_LEFT}
+          />
           Please Select an Account
         </HeadingText>
       </div>

--- a/nerdlets/network-telemetry-overview/network-telemetry-nerdlet.jsx
+++ b/nerdlets/network-telemetry-overview/network-telemetry-nerdlet.jsx
@@ -40,7 +40,7 @@ export default class NetworkTelemetryNerdlet extends React.Component {
     return (
       <div className='select-account'>
         <HeadingText type={HeadingText.TYPE.HEADING_1}>
-          <Icon sizeType={Icon.SIZE_TYPE.LARGE} type={Icon.TYPE.INTERFACE__ARROW__ARROW_LEFT} />
+          <Icon type={Icon.TYPE.INTERFACE__ARROW__ARROW_LEFT} />
           Please Select an Account
         </HeadingText>
       </div>

--- a/nerdlets/network-telemetry-overview/styles.scss
+++ b/nerdlets/network-telemetry-overview/styles.scss
@@ -173,9 +173,6 @@ label {
 
 .select-account {
   margin: 20px;
-  span {
-    margin-right: 10px;
-  }
 }
 
 .ip-address {

--- a/nerdlets/network-telemetry-overview/styles.scss
+++ b/nerdlets/network-telemetry-overview/styles.scss
@@ -173,6 +173,9 @@ label {
 
 .select-account {
   margin: 20px;
+  span {
+    margin-right: 10px;
+  }
 }
 
 .ip-address {


### PR DESCRIPTION
This PR updates the nr1 Icon which no longer uses the sizeType prop. Icon sizes can be adjusted via a size suffix on the icon type, but not all icons have this option.
There is only one size for the arrow and an inline style gets applied in the platform with the font size. We could use `!important` to get the icon to be larger, or just accept a style change with a smaller arrow.

<img width="489" alt="Screen Shot 2021-01-29 at 12 02 15 PM" src="https://user-images.githubusercontent.com/39655074/106332490-c903e400-623b-11eb-9a64-ad62e555b9a0.png">
<img width="409" alt="Screen Shot 2021-01-29 at 12 19 06 PM" src="https://user-images.githubusercontent.com/39655074/106332491-ca351100-623b-11eb-8b82-ba3a18a5c2d0.png">
